### PR TITLE
Create MCP server with addition tool

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.languageServer": "None"
+}

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,0 +1,168 @@
+# Simple MCP Server Example
+
+This directory contains a simple implementation of a Model Context Protocol (MCP) server in Python that exposes an "add" tool for basic arithmetic operations.
+
+## What is MCP?
+
+Model Context Protocol (MCP) is a standardized way for AI assistants to connect with external data sources and tools. It allows AI models to access real-time information and perform actions through a structured, secure interface.
+
+## Files
+
+- `mcp_server.py` - The main MCP server implementation
+- `client_example.py` - A simple client to test the server
+- `manual_test.py` - Manual testing script showing raw JSON-RPC requests
+- `README.md` - This documentation file
+
+## Features
+
+The MCP server implements:
+
+- **Tool capability**: Exposes an "add" tool that can add two numbers
+- **JSON-RPC protocol**: Communicates using JSON-RPC 2.0 over stdin/stdout
+- **Error handling**: Proper error responses for invalid requests
+- **Async support**: Built with asyncio for non-blocking operations
+
+## How to Run
+
+### Running the Server Directly
+
+```bash
+cd mcp_server
+python3 mcp_server.py
+```
+
+The server will wait for JSON-RPC requests on stdin and respond on stdout.
+
+### Testing with the Client Example
+
+```bash
+cd mcp_server
+python3 client_example.py
+```
+
+This will start the server automatically and demonstrate:
+1. Server initialization
+2. Listing available tools
+3. Calling the add tool with various inputs
+4. Error handling
+
+### Manual Testing with Raw JSON-RPC
+
+```bash
+cd mcp_server
+python3 manual_test.py
+```
+
+This script shows exactly what JSON-RPC requests and responses look like, making it easier to understand the protocol.
+
+## MCP Protocol Flow
+
+1. **Initialize**: Client sends an `initialize` request to establish the connection
+2. **List Tools**: Client requests available tools with `tools/list`
+3. **Call Tool**: Client calls a specific tool with `tools/call`
+
+### Example Requests/Responses
+
+**Initialize Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {"name": "client", "version": "1.0.0"}
+  }
+}
+```
+
+**Initialize Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {"tools": {}},
+    "serverInfo": {"name": "simple-math-server", "version": "1.0.0"}
+  }
+}
+```
+
+**Tool Call Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "add",
+    "arguments": {"a": 5, "b": 3}
+  }
+}
+```
+
+**Tool Call Response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "The sum of 5 and 3 is 8"
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+## Extending the Server
+
+To add more tools:
+
+1. Define a new `Tool` object in the `__init__` method
+2. Add a handler method (e.g., `_call_multiply_tool`)
+3. Update the `handle_call_tool` method to route to your new handler
+
+Example:
+```python
+# In __init__:
+"multiply": Tool(
+    name="multiply",
+    description="Multiply two numbers",
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "a": {"type": "number", "description": "First number"},
+            "b": {"type": "number", "description": "Second number"}
+        },
+        "required": ["a", "b"]
+    }
+)
+
+# Handler method:
+async def _call_multiply_tool(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    a = arguments.get("a")
+    b = arguments.get("b")
+    result = a * b
+    return {
+        "content": [{"type": "text", "text": f"{a} × {b} = {result}"}],
+        "isError": False
+    }
+```
+
+## Requirements
+
+- Python 3.7 or higher
+- No external dependencies (uses only standard library)
+
+## Notes
+
+- The server uses stdin/stdout for communication (standard for MCP servers)
+- Error messages are logged to stderr
+- The server runs indefinitely until interrupted (Ctrl+C)
+- All communication follows the JSON-RPC 2.0 specification

--- a/mcp_server/client_example.py
+++ b/mcp_server/client_example.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Simple MCP Client Example
+This client demonstrates how to interact with the MCP server.
+"""
+
+import asyncio
+import json
+import subprocess
+import sys
+from typing import Any, Dict
+
+
+class MCPClient:
+    """Simple MCP Client implementation."""
+    
+    def __init__(self, server_command: list):
+        self.server_command = server_command
+        self.process = None
+        self.request_id = 0
+    
+    async def start_server(self):
+        """Start the MCP server process."""
+        self.process = await asyncio.create_subprocess_exec(
+            *self.server_command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE
+        )
+        print("MCP Server started")
+    
+    async def send_request(self, method: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
+        """Send a request to the MCP server."""
+        if not self.process or not self.process.stdin or not self.process.stdout:
+            raise RuntimeError("Server not started or streams not available")
+        
+        self.request_id += 1
+        request = {
+            "jsonrpc": "2.0",
+            "id": self.request_id,
+            "method": method,
+            "params": params or {}
+        }
+        
+        # Send request
+        request_json = json.dumps(request) + "\n"
+        self.process.stdin.write(request_json.encode())
+        await self.process.stdin.drain()
+        
+        # Read response
+        response_line = await self.process.stdout.readline()
+        response = json.loads(response_line.decode().strip())
+        
+        return response
+    
+    async def initialize(self):
+        """Initialize the MCP connection."""
+        response = await self.send_request("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "simple-client",
+                "version": "1.0.0"
+            }
+        })
+        print("Initialization response:", response)
+        return response
+    
+    async def list_tools(self):
+        """List available tools."""
+        response = await self.send_request("tools/list")
+        print("Available tools:", response)
+        return response
+    
+    async def call_add_tool(self, a: float, b: float):
+        """Call the add tool with two numbers."""
+        response = await self.send_request("tools/call", {
+            "name": "add",
+            "arguments": {"a": a, "b": b}
+        })
+        print(f"Add tool result: {response}")
+        return response
+    
+    async def close(self):
+        """Close the connection and terminate the server."""
+        if self.process:
+            if self.process.stdin:
+                self.process.stdin.close()
+            await self.process.wait()
+            print("MCP Server stopped")
+
+
+async def main():
+    """Main example function."""
+    print("=== MCP Client Example ===\n")
+    
+    # Initialize client with server command
+    client = MCPClient([sys.executable, "mcp_server.py"])
+    
+    try:
+        # Start the server
+        await client.start_server()
+        
+        # Initialize the connection
+        print("1. Initializing connection...")
+        await client.initialize()
+        print()
+        
+        # List available tools
+        print("2. Listing available tools...")
+        await client.list_tools()
+        print()
+        
+        # Test the add tool with different inputs
+        print("3. Testing the add tool...")
+        test_cases = [
+            (5, 3),
+            (10.5, 2.7),
+            (-5, 8),
+            (0, 0),
+            (100, -50)
+        ]
+        
+        for a, b in test_cases:
+            await client.call_add_tool(a, b)
+        print()
+        
+        print("4. Testing error handling...")
+        # This will demonstrate error handling (missing arguments)
+        response = await client.send_request("tools/call", {
+            "name": "add",
+            "arguments": {"a": 5}  # Missing 'b'
+        })
+        print(f"Error case result: {response}")
+        
+    except Exception as e:
+        print(f"Error: {e}")
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_server/manual_test.py
+++ b/mcp_server/manual_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Manual Test Script for MCP Server
+This script demonstrates how to manually send JSON-RPC requests to the MCP server.
+"""
+
+import json
+import subprocess
+import sys
+import time
+
+
+def send_request_to_server(server_process, request):
+    """Send a JSON-RPC request to the server and get the response."""
+    request_json = json.dumps(request) + "\n"
+    server_process.stdin.write(request_json.encode())
+    server_process.stdin.flush()
+    
+    response_line = server_process.stdout.readline()
+    return json.loads(response_line.decode().strip())
+
+
+def main():
+    """Manual testing of the MCP server."""
+    print("=== Manual MCP Server Test ===\n")
+    
+    # Start the server
+    server_process = subprocess.Popen(
+        [sys.executable, "mcp_server.py"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=False
+    )
+    
+    try:
+        print("Server started. Sending requests...\n")
+        
+        # Test 1: Initialize
+        print("1. Sending initialize request...")
+        init_request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "manual-test", "version": "1.0.0"}
+            }
+        }
+        
+        print(f"Request: {json.dumps(init_request, indent=2)}")
+        response = send_request_to_server(server_process, init_request)
+        print(f"Response: {json.dumps(response, indent=2)}\n")
+        
+        # Test 2: List tools
+        print("2. Sending tools/list request...")
+        list_request = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }
+        
+        print(f"Request: {json.dumps(list_request, indent=2)}")
+        response = send_request_to_server(server_process, list_request)
+        print(f"Response: {json.dumps(response, indent=2)}\n")
+        
+        # Test 3: Call add tool
+        print("3. Sending tools/call request (add 15 + 27)...")
+        call_request = {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "add",
+                "arguments": {"a": 15, "b": 27}
+            }
+        }
+        
+        print(f"Request: {json.dumps(call_request, indent=2)}")
+        response = send_request_to_server(server_process, call_request)
+        print(f"Response: {json.dumps(response, indent=2)}\n")
+        
+        # Test 4: Invalid method
+        print("4. Sending invalid method request...")
+        invalid_request = {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "invalid/method",
+            "params": {}
+        }
+        
+        print(f"Request: {json.dumps(invalid_request, indent=2)}")
+        response = send_request_to_server(server_process, invalid_request)
+        print(f"Response: {json.dumps(response, indent=2)}\n")
+        
+        print("Manual testing completed successfully!")
+        
+    except Exception as e:
+        print(f"Error during testing: {e}")
+    finally:
+        # Clean up
+        if server_process.stdin:
+            server_process.stdin.close()
+        server_process.terminate()
+        server_process.wait()
+        print("Server stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/mcp_server.py
+++ b/mcp_server/mcp_server.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Simple MCP (Model Context Protocol) Server Example
+This server exposes a simple "add" tool that performs basic arithmetic addition.
+"""
+
+import asyncio
+import json
+import sys
+from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class Tool:
+    """Represents a tool that can be called by the client."""
+    name: str
+    description: str
+    inputSchema: Dict[str, Any]
+
+
+@dataclass
+class ToolCallRequest:
+    """Represents a request to call a tool."""
+    name: str
+    arguments: Dict[str, Any]
+
+
+@dataclass
+class ToolCallResult:
+    """Represents the result of a tool call."""
+    content: List[Dict[str, Any]]
+    isError: bool = False
+
+
+class MCPServer:
+    """Simple MCP Server implementation."""
+    
+    def __init__(self):
+        self.tools = {
+            "add": Tool(
+                name="add",
+                description="Add two numbers together",
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "a": {
+                            "type": "number",
+                            "description": "First number to add"
+                        },
+                        "b": {
+                            "type": "number",
+                            "description": "Second number to add"
+                        }
+                    },
+                    "required": ["a", "b"]
+                }
+            )
+        }
+    
+    async def handle_initialize(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle initialization request."""
+        return {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {
+                "tools": {}
+            },
+            "serverInfo": {
+                "name": "simple-math-server",
+                "version": "1.0.0"
+            }
+        }
+    
+    async def handle_list_tools(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle tools/list request."""
+        return {
+            "tools": [asdict(tool) for tool in self.tools.values()]
+        }
+    
+    async def handle_call_tool(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle tools/call request."""
+        tool_name = params.get("name")
+        arguments = params.get("arguments", {})
+        
+        if tool_name == "add":
+            return await self._call_add_tool(arguments)
+        else:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Unknown tool: {tool_name}"
+                    }
+                ],
+                "isError": True
+            }
+    
+    async def _call_add_tool(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute the add tool."""
+        try:
+            a = arguments.get("a")
+            b = arguments.get("b")
+            
+            if a is None or b is None:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Missing required arguments 'a' and/or 'b'"
+                        }
+                    ],
+                    "isError": True
+                }
+            
+            result = a + b
+            
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"The sum of {a} and {b} is {result}"
+                    }
+                ],
+                "isError": False
+            }
+            
+        except Exception as e:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Error performing addition: {str(e)}"
+                    }
+                ],
+                "isError": True
+            }
+    
+    async def handle_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle incoming MCP request."""
+        method = request.get("method")
+        params = request.get("params", {})
+        
+        if method == "initialize":
+            result = await self.handle_initialize(params)
+        elif method == "tools/list":
+            result = await self.handle_list_tools(params)
+        elif method == "tools/call":
+            result = await self.handle_call_tool(params)
+        else:
+            result = {
+                "error": {
+                    "code": -32601,
+                    "message": f"Method not found: {method}"
+                }
+            }
+        
+        return {
+            "jsonrpc": "2.0",
+            "id": request.get("id"),
+            "result": result
+        }
+    
+    async def run(self):
+        """Run the MCP server."""
+        print("MCP Server starting...", file=sys.stderr)
+        print("Server capabilities: tools (add)", file=sys.stderr)
+        
+        try:
+            while True:
+                # Read JSON-RPC request from stdin
+                line = await asyncio.get_event_loop().run_in_executor(
+                    None, sys.stdin.readline
+                )
+                
+                if not line:
+                    break
+                
+                try:
+                    request = json.loads(line.strip())
+                    response = await self.handle_request(request)
+                    
+                    # Send response to stdout
+                    print(json.dumps(response))
+                    sys.stdout.flush()
+                    
+                except json.JSONDecodeError as e:
+                    print(f"JSON decode error: {e}", file=sys.stderr)
+                except Exception as e:
+                    print(f"Error processing request: {e}", file=sys.stderr)
+                    
+        except KeyboardInterrupt:
+            print("Server shutting down...", file=sys.stderr)
+
+
+async def main():
+    """Main entry point."""
+    server = MCPServer()
+    await server.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
A new `mcp_server/` directory was established to house a Python-based Model Context Protocol (MCP) server example.

*   The `mcp_server/mcp_server.py` file was created, implementing a basic MCP server. It adheres to JSON-RPC 2.0 over stdin/stdout, exposing an `add` tool that sums two numbers. Handlers for `initialize`, `tools/list`, and `tools/call` methods were included, along with error handling.
*   A `mcp_server/client_example.py` was added to demonstrate programmatic interaction with the server. This client covers the full flow: server startup, initialization, tool listing, and calling the `add` tool, including an error case for missing arguments.
*   A `mcp_server/manual_test.py` script was introduced to showcase raw JSON-RPC communication. It sends direct JSON requests to the server, illustrating the protocol's structure.
*   Comprehensive documentation was provided in `mcp_server/README.md`, explaining MCP, the project structure, usage instructions for both automated and manual tests, and guidance for extending the server with new tools.
*   A `.vscode/settings.json` file was added to disable the Python language server, likely for environment setup.

The changes provide a complete, self-contained example of an MCP server with a simple `add` tool, accompanied by client examples and documentation.